### PR TITLE
Add an option for rebuildXMLFile to add root FTL tags

### DIFF
--- a/src/main/java/net/vhati/modmanager/core/ModPatchThread.java
+++ b/src/main/java/net/vhati/modmanager/core/ModPatchThread.java
@@ -391,7 +391,7 @@ public class ModPatchThread extends Thread {
 						else if ( fileName.endsWith( ".xml" ) ) {
 							innerPath = checkCase( innerPath, knownPaths, knownPathsLower );
 
-							InputStream fixedStream = ModUtilities.rebuildXMLFile( zis, ultimateEncoding, modFile.getName()+":"+parentPath+fileName );
+							InputStream fixedStream = ModUtilities.rebuildXMLFile( zis, ultimateEncoding, modFile.getName()+":"+parentPath+fileName, false );
 
 							if ( !moddedItems.contains( innerPath ) ) {
 								moddedItems.add( innerPath );

--- a/src/main/java/net/vhati/modmanager/core/ModUtilities.java
+++ b/src/main/java/net/vhati/modmanager/core/ModUtilities.java
@@ -373,7 +373,7 @@ public class ModUtilities {
 	 * @see net.vhati.modmanager.core.XMLPatcher
 	 * @see net.vhati.modmanager.core.SloppyXMLOutputProcessor
 	 */
-	public static InputStream rebuildXMLFile( InputStream srcStream, String encoding, String srcDescription ) throws IOException, JDOMException {
+	public static InputStream rebuildXMLFile( InputStream srcStream, String encoding, String srcDescription, boolean addFTLTag ) throws IOException, JDOMException {
 		Pattern xmlDeclPtn = Pattern.compile( "<[?]xml [^>]*?[?]>\n*" );
 
 		String srcText = decodeText( srcStream, srcDescription ).text;
@@ -387,6 +387,19 @@ public class ModUtilities {
 				" xmlns:mod-after='mod-after'>"+ srcText +"</wrapper>";
 		Document doc = parseStrictOrSloppyXML( srcText, srcDescription+" (wrapped)" );
 		srcText = null;
+
+		// Wrap the document in a root <FTL> tag if required.
+		// This is used by Project Wormhole.
+		if (addFTLTag && doc.getRootElement().getChild("FTL") == null) {
+			Element newRoot = doc.getRootElement();
+			Element ftlNode = new Element("FTL");
+			List<Content> rootContent = new ArrayList<>(newRoot.getContent());
+			for (Content c : rootContent) {
+				c.detach();
+			}
+			ftlNode.addContent(rootContent);
+			newRoot.addContent(ftlNode);
+		}
 
 		// Bake XML into text, filtering the stream to standardize newlines and encode.
 

--- a/src/main/java/net/vhati/modmanager/ui/ModXMLSandbox.java
+++ b/src/main/java/net/vhati/modmanager/ui/ModXMLSandbox.java
@@ -387,7 +387,7 @@ public class ModXMLSandbox extends JFrame implements ActionListener {
 			if ( innerPath == null ) return;
 
 			is = pack.getInputStream( innerPath );
-			InputStream rebuiltStream = ModUtilities.rebuildXMLFile( is, encoding, pack.getName()+":"+innerPath );
+			InputStream rebuiltStream = ModUtilities.rebuildXMLFile( is, encoding, pack.getName()+":"+innerPath, false );
 			String rebuiltText = ModUtilities.decodeText( rebuiltStream, "Sandbox Main XML" ).text;
 			is.close();
 


### PR DESCRIPTION
While it's not used by Slipstream itself, this is useful for Project Wormhole, which uses large parts of Slipstream code for it's own mod loading.

Upstreaming this patch helps Wormhole keep it's copy of Slipstream up-to-date, as it removes a patch that would otherwise need to be applied whenever Slipstream is updated.